### PR TITLE
API

### DIFF
--- a/psi/__init__.py
+++ b/psi/__init__.py
@@ -1,0 +1,32 @@
+from psi.protocols import Protocols
+from psi.servers import AbstractServer
+
+
+def client_intersect(elements, ip, port, protocol=Protocols.RSA):
+    """
+    Intersect client elements with remote elements on the server in a way that
+    the client learns the intersection while the server learns nothing.
+
+    Args:
+        elements: client set to intersect with the server set.
+        ip: ip address of the server holding the server set.
+        port: port number of the server holding the server set.
+        protocol: Protocol to be used to do the private set intersection.
+
+    Returns:
+        The intersection of the client and server sets.
+    """
+    pass
+
+
+def create_server(elements, ip, port, protocol=Protocols.RSA):
+    """
+    Create a server for a specified protocol.
+
+    Args:
+        elements: server set to intersect with the client set.
+        ip: ip address to listen to.
+        port: port number to listen to.
+        protocol: server's PSI protocol to use.
+    """
+    pass

--- a/psi/__init__.py
+++ b/psi/__init__.py
@@ -1,32 +1,51 @@
 from psi.protocols import Protocols
 from psi.servers import AbstractServer
+from psi.clients import AbstractClient
 
 
-def client_intersect(elements, ip, port, protocol=Protocols.RSA):
+def client_intersect(elements, base_url, protocol=Protocols.RSA):
     """
     Intersect client elements with remote elements on the server in a way that
     the client learns the intersection while the server learns nothing.
 
     Args:
         elements: client set to intersect with the server set.
-        ip: ip address of the server holding the server set.
-        port: port number of the server holding the server set.
+        base_url: server base url, will be extended with step endpoints.
         protocol: Protocol to be used to do the private set intersection.
 
     Returns:
         The intersection of the client and server sets.
     """
-    pass
+    client = create_client(elements, base_url, protocol)
+    return client.intersect()
 
 
-def create_server(elements, ip, port, protocol=Protocols.RSA):
+def create_server(elements, protocol=Protocols.RSA):
     """
     Create a server for a specified protocol.
 
     Args:
         elements: server set to intersect with the client set.
-        ip: ip address to listen to.
-        port: port number to listen to.
         protocol: server's PSI protocol to use.
+
+    Returns:
+        A Server instance.
     """
-    pass
+    # Return specific server based on the protocol
+    return AbstractServer(elements)
+
+
+def create_client(elements, base_url, protocol=Protocols.RSA):
+    """
+    Create a client for a specified protocol.
+
+    Args:
+        elements: client set to intersect with the server set.
+        base_url: server base url, will be extended with step endpoints.
+        protocol: client's PSI protocol to use.
+
+    Returns:
+        A Client instance.
+    """
+    # Return specific client based on the protocol
+    return AbstractClient(elements, base_url)

--- a/psi/clients/__init__.py
+++ b/psi/clients/__init__.py
@@ -1,0 +1,26 @@
+from abc import ABC
+
+
+class AbstractClient(ABC):
+    """
+    Client running a specified PSI protocol.
+    """
+
+    def __init__(self, elements, base_url):
+        """
+        Args:
+            elements: client set to intersect with the server set.
+            base_url: server base url, will be extended with step endpoints.
+        """
+        self._elements = elements
+        self._base_url = base_url
+
+    def intersect(self):
+        """
+        Run all steps required for the specific protocol the client 
+        implements.
+
+        Returns:
+            The intersection of the client and server sets.
+        """
+        return []

--- a/psi/protocols.py
+++ b/psi/protocols.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class Protocols(Enum):
+    RSA_V1 = 0
+    # Default RSA
+    RSA = RSA_V1
+    # DH = 1

--- a/psi/servers/__init__.py
+++ b/psi/servers/__init__.py
@@ -1,0 +1,22 @@
+from abc import ABC
+
+
+class AbstractServer(ABC):
+    """
+    Server running a specified PSI protocol.
+    """
+
+    def __init__(self, ip, port):
+        """
+        Args:
+            ip: ip address to listen to
+            port: port number to listen to
+        """
+        self._ip = ip
+        self._port = port
+
+    def start(self):
+        """
+        Start the server.
+        """
+        pass

--- a/psi/servers/__init__.py
+++ b/psi/servers/__init__.py
@@ -6,17 +6,9 @@ class AbstractServer(ABC):
     Server running a specified PSI protocol.
     """
 
-    def __init__(self, ip, port):
+    def __init__(self, elements):
         """
         Args:
-            ip: ip address to listen to
-            port: port number to listen to
+            elements: set set to intersect with the client set.
         """
-        self._ip = ip
-        self._port = port
-
-    def start(self):
-        """
-        Start the server.
-        """
-        pass
+        self._elements = elements


### PR DESCRIPTION
This PR proposes an API for the PSI libraries. I thought that a general purpose library should only let the user inputs its set, the protocol he wanna use and information about the remote server, the rest should be transparent, everything should be taken care of in the `client_intersect` function. On the server side, each protocol should have its own implementation, but we provide a constructor function `create_server` that take the server set, the protocol we wanna use and information about how to listen to queries, then the server should be started with `server.start()`.

An example of how to use this API:

#### Server

```python
import psi

elements = [1, 2, 3, 4, 5, 6]
server = psi.create_server(elements, ip='x.x.x.x', port=n)
server.start()
```

#### Client

```python
import psi

elements = [2, 5, 10,]
intersection = psi.client_intersect(elements, ip='x.x.x.x', port=n)
```